### PR TITLE
Removed rsvp termination from Character_Death

### DIFF
--- a/hgapp/characters/models.py
+++ b/hgapp/characters/models.py
@@ -1118,8 +1118,6 @@ class Character_Death(models.Model):
                                      null=True,
                                      blank=True)
     def save(self, *args, **kwargs):
-        if self.pk is None:
-            self.relevant_character.delete_upcoming_attendances()
         super(Character_Death, self).save(*args, **kwargs)
 
 class Graveyard_Header(models.Model):


### PR DESCRIPTION
Tested. You'll have to trust me that I killed off deadboi before taking these screenshots, the removal of those two lines did the trick

![AlreadyDeadCharInRSVPScreen](https://user-images.githubusercontent.com/7707883/111016992-b9f97100-8365-11eb-818a-d15fcef00d63.png)
![CoinOnChar](https://user-images.githubusercontent.com/7707883/111016998-c251ac00-8365-11eb-96a4-7e5f2d8e46fb.png)
