### PR TITLE
Replaced .name with .display for power badge

### DIFF
--- a/hgapp/powers/templates/powers/power_badge_snippet.html
+++ b/hgapp/powers/templates/powers/power_badge_snippet.html
@@ -39,14 +39,14 @@
                 <ul>
                 {% for instance in power_full.latest_revision.enhancement_instance_set.all %}
                     <li>
-                    {% if instance.relevant_enhancement.eratta%}
+                        <b>{{instance.relevant_enhancement.name}}:</b> {{instance.relevant_enhancement.description}}
+                        {% if instance.relevant_enhancement.eratta%}
                         <span data-toggle="tooltip" 
                             title="{{instance.relevant_enhancement.eratta}}"
                             data-placement="top">
                             <i class="fa fa-question-circle fa-1x"></i>
                         </span>
-                    {% endif %}
-                        <b>{{instance.relevant_enhancement.name}}:</b> {{instance.relevant_enhancement.description}}
+                        {% endif %}
                         {% if instance.detail%}
                             <ul><li>
                                 {{instance.relevant_enhancement.detail_field_label}}: {{instance.detail}}
@@ -63,14 +63,14 @@
                 <ul>
                 {% for instance in power_full.latest_revision.drawback_instance_set.all %}
                     <li>
-                    {% if instance.relevant_drawback.eratta%}
+                        <b>{{instance.relevant_drawback.name}}:</b> {{instance.relevant_drawback.description}}
+                        {% if instance.relevant_drawback.eratta%}
                         <span data-toggle="tooltip" 
                             title="{{instance.relevant_drawback.eratta}}"
                             data-placement="top">
                             <i class="fa fa-question-circle fa-1x"></i>
                         </span>
                     {% endif %}
-                        <b>{{instance.relevant_drawback.name}}:</b> {{instance.relevant_drawback.description}}
                         {% if instance.detail%}
                             <ul><li>
                                 {{instance.relevant_drawback.detail_field_label}}: {{instance.detail}}

--- a/hgapp/powers/templates/powers/power_badge_snippet.html
+++ b/hgapp/powers/templates/powers/power_badge_snippet.html
@@ -31,37 +31,54 @@
          role="tabpanel"
          aria-labelledby="collapse-power-{{power_full.id}}-heading">
         <p>
-            <b>System: <br></b>
             {{power_full.latest_revision.render_system}}
         </p>
         {% if power_full.latest_revision.enhancement_instance_set.all %}
             <p>
-                <b>Enhancements:</b>
+                <b>Enhancements</b>
+                <ul>
                 {% for instance in power_full.latest_revision.enhancement_instance_set.all %}
-                    <span class="power-badge-modifier"
-                          style="display: inline-block;"
-                          data-toggle="tooltip"
-                          data-html="true"
-                          title='{{instance.relevant_enhancement.description}}
-                          {{instance.relevant_enhancement.eratta|linebreaks}}'>
-                        {{instance.relevant_enhancement.display}}
-                    </span>
+                    <li>
+                    {% if instance.relevant_enhancement.eratta%}
+                        <span data-toggle="tooltip" 
+                            title="{{instance.relevant_enhancement.eratta}}"
+                            data-placement="top">
+                            <i class="fa fa-question-circle fa-1x"></i>
+                        </span>
+                    {% endif %}
+                        <b>{{instance.relevant_enhancement.name}}:</b> {{instance.relevant_enhancement.description}}
+                        {% if instance.detail%}
+                            <ul><li>
+                                {{instance.relevant_enhancement.detail_field_label}}: {{instance.detail}}
+                            </li></ul>
+                        {% endif %}
+                    </li>
                 {% endfor %}
+                </ul>
             </p>
         {% endif %}
         {% if power_full.latest_revision.drawback_instance_set.all %}
             <p>
-                <b>Drawbacks:</b>
+                <b>Drawbacks</b>
+                <ul>
                 {% for instance in power_full.latest_revision.drawback_instance_set.all %}
-                    <span style="display: inline-block;"
-                            class="power-badge-modifier"
-                          data-toggle="tooltip"
-                          data-html="true"
-                          title='{{instance.relevant_drawback.description|linebreaks}}
-                          {{instance.relevant_drawback.eratta|linebreaks}}'>
-                        {{instance.relevant_drawback.display}}
-                    </span>
+                    <li>
+                    {% if instance.relevant_drawback.eratta%}
+                        <span data-toggle="tooltip" 
+                            title="{{instance.relevant_drawback.eratta}}"
+                            data-placement="top">
+                            <i class="fa fa-question-circle fa-1x"></i>
+                        </span>
+                    {% endif %}
+                        <b>{{instance.relevant_drawback.name}}:</b> {{instance.relevant_drawback.description}}
+                        {% if instance.detail%}
+                            <ul><li>
+                                {{instance.relevant_drawback.detail_field_label}}: {{instance.detail}}
+                            </li></ul>
+                        {% endif %}
+                    </li>
                 {% endfor %}
+                </ul>
             </p>
         {% endif %}
         {% if power_full.example_description %}

--- a/hgapp/powers/templates/powers/power_badge_snippet.html
+++ b/hgapp/powers/templates/powers/power_badge_snippet.html
@@ -44,7 +44,7 @@
                           data-html="true"
                           title='{{instance.relevant_enhancement.description}}
                           {{instance.relevant_enhancement.eratta|linebreaks}}'>
-                        {{instance.relevant_enhancement.name}}
+                        {{instance.relevant_enhancement.display}}
                     </span>
                 {% endfor %}
             </p>
@@ -59,7 +59,7 @@
                           data-html="true"
                           title='{{instance.relevant_drawback.description|linebreaks}}
                           {{instance.relevant_drawback.eratta|linebreaks}}'>
-                        {{instance.relevant_drawback.name}}
+                        {{instance.relevant_drawback.display}}
                     </span>
                 {% endfor %}
             </p>


### PR DESCRIPTION
Here's an example of what the display looks like. I think the parens are... _okay_ let me know what you think, maybe we could add a new .display_snippet to the model or something.
![EnhancementDrawbackDisplay](https://user-images.githubusercontent.com/7707883/111020563-b4a72100-837b-11eb-8ada-46f1acaa04c4.png)
